### PR TITLE
fix: mirrored chart tarballs should reside under charts/

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -27,7 +27,10 @@ jobs:
 
       - name: Download all Helm charts
         if: github.ref == 'refs/heads/main'
-        run: helm-mirror "$REGISTRY_SOURCE" "$(pwd)" --all-versions --verbose --new-root-url "https://${{ env.GH_PAGES_URL }}" --chart-name "${CHART_NAME}"
+        run: |
+          mkdir -p charts
+          helm-mirror "$REGISTRY_SOURCE" "$(pwd)/charts" --all-versions --verbose --new-root-url "https://${{ env.GH_PAGES_URL }}" --chart-name "${CHART_NAME}"
+          mv charts/index.yaml .
 
       - name: "Commit changes"
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Description
Change will explicitly download charts into a charts directory so the generated index.yaml matches the path

## Related Issue(s)
Fixes #1 

## How to test
It's hard to test this one without actually running your actions, but running the commands manually locally appears to have the correct result